### PR TITLE
Remove hardcoded ssh path (issue #23)

### DIFF
--- a/pkg/netcopy/netcopy.go
+++ b/pkg/netcopy/netcopy.go
@@ -95,7 +95,7 @@ func (r *RsyncNetworkCopier) Copy(ctx context.Context, sources []HostPath, dest 
 
 	cmd := exec.CommandContext(ctx, "rsync", args...)
 	cmd.Env = []string{
-		fmt.Sprintf(`RSYNC_RSH=/usr/bin/ssh -i "%s" -o UserKnownHostsFile=%s -o PubkeyAcceptedKeyTypes=+ssh-rsa`, keyStore.KeyPath(), knownHostsFile.Name()),
+		fmt.Sprintf(`RSYNC_RSH=ssh -i "%s" -o UserKnownHostsFile=%s -o PubkeyAcceptedKeyTypes=+ssh-rsa`, keyStore.KeyPath(), knownHostsFile.Name()),
 	}
 
 	log.Debugf("executing rsync command:")


### PR DESCRIPTION
- as discovere in [issue 23](https://github.com/LINBIT/virter/issues/23) the rsync command for `virter vm cp` will use /usr/bin/ssh
- the command would fail if `ssh` was located elsewhere
- removed the path at line 98 to allow the system to use the `ssh` binary located in the users path

Changes to be committed:
	modified:   pkg/netcopy/netcopy.go


## Testing

I built `virter` locally and ran the same commands identified in issue #23 . 

```shell

# Original virter in system path
λ virter vm cp default.xml rke-cp:~ --loglevel debug
DEBU[0000] Using config file: /home/dustin/.config/virter/virter.toml 
DEBU[0000] executing rsync command:                     
DEBU[0000] RSYNC_RSH=/usr/bin/ssh -i "/home/dustin/.ssh/id_rsa_temp" -o UserKnownHostsFile=/tmp/rsync-known-hosts-854713461 -o PubkeyAcceptedKeyTypes=+ssh-rsa /run/current-system/sw/bin/rsync --recursive --perms --times --protect-args default.xml root@192.168.122.100:~ 
DEBU[0000] rsync output:
rsync: [sender] Failed to exec /usr/bin/ssh: No such file or directory (2)
rsync error: error in IPC code (code 14) at pipe.c(85) [sender=3.2.7]
rsync: [sender] safe_write failed to write 6 bytes to fd 4: Broken pipe (32)
rsync error: error in rsync protocol data stream (code 12) at io.c(326) [sender=3.2.7] 
FATA[0000] error executing rsync: exit status 12        

# Updated Virter not in path
dustin in 🌐 rembot in ☸ default in ~ on ☁️  (us-west-2) at 10:46:48 
λ ./virter vm cp default.xml rke-cp:~ --loglevel debug
DEBU[0000] Using config file: /home/dustin/.config/virter/virter.toml 
DEBU[0000] executing rsync command:                     
DEBU[0000] RSYNC_RSH=ssh -i "/home/dustin/.ssh/id_rsa_temp" -o UserKnownHostsFile=/tmp/rsync-known-hosts-725856400 -o PubkeyAcceptedKeyTypes=+ssh-rsa /run/current-system/sw/bin/rsync --recursive --perms --times --protect-args default.xml root@192.168.122.100:~ 
```

As you can see the copy was successful.

Admittedly, logic could be added to test for the binaries in `$PATH`