### PR TITLE
If 'truncate' fails for /etc/machine-id during 'commit', attempt with 'sudo' before giving up

### DIFF
--- a/cmd/image_build.go
+++ b/cmd/image_build.go
@@ -280,7 +280,7 @@ func imageBuildCommand() *cobra.Command {
 	buildCmd.Flags().BoolVar(&resetMachineID, "reset-machine-id", true, "Whether or not to clear the /etc/machine-id file after provisioning")
 	buildCmd.Flags().VarP(&vmPullPolicy, "pull-policy", "", "Whether or not to pull the source image.")
 	buildCmd.Flags().VarP(&vmPullPolicy, "vm-pull-policy", "", fmt.Sprintf("Whether or not to pull the source image. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
-	buildCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used durign provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
+	buildCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used during provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
 	buildCmd.Flags().BoolVarP(&push, "push", "", false, "Push the image after building")
 	buildCmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Disable caching for the image build")
 	buildCmd.Flags().StringVarP(&buildId, "build-id", "", "", "Build ID used to determine if an image needs to be rebuild.")

--- a/cmd/vm_exec.go
+++ b/cmd/vm_exec.go
@@ -64,7 +64,7 @@ func vmExecCommand() *cobra.Command {
 
 	execCmd.Flags().VarP(&provFile, "provision", "p", "name of toml file containing provisioning steps")
 	execCmd.Flags().StringArrayVarP(&provisionOverrides, "set", "s", []string{}, "set/override provisioning steps")
-	execCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used durign provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
+	execCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used during provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
 
 	return execCmd
 }

--- a/cmd/vm_run.go
+++ b/cmd/vm_run.go
@@ -308,7 +308,7 @@ func vmRunCommand() *cobra.Command {
 
 	runCmd.Flags().VarP(&vmPullPolicy, "pull-policy", "", "Whether or not to pull the source image.")
 	runCmd.Flags().VarP(&vmPullPolicy, "vm-pull-policy", "", fmt.Sprintf("Whether or not to pull the source image. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
-	runCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used durign provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
+	runCmd.Flags().VarP(&containerPullPolicy, "container-pull-policy", "", fmt.Sprintf("Whether or not to pull container images used during provisioning. Overrides the `pull` value of every provision step. Valid values: [%s, %s, %s]", pullpolicy.Always, pullpolicy.IfNotExist, pullpolicy.Never))
 	runCmd.Flags().StringVarP(&user, "user", "u", "root", "Remote user for ssh session")
 	runCmd.Flags().BoolVarP(&vncEnabled, "vnc", "", false, "whether to configure VNC (remote GUI access) for the VM (defaults to false)")
 	runCmd.Flags().IntVar(&vncPort, "vnc-port", 0, "VNC port. Defaults to 6000+id of this VM")

--- a/internal/virter/vm.go
+++ b/internal/virter/vm.go
@@ -477,9 +477,15 @@ func (v *Virter) VMCommit(ctx context.Context, afterNotifier AfterNotifier, vmNa
 		err = v.VMExecShell(
 			ctx, []string{vmName},
 			&ProvisionShellStep{Script: "truncate -c -s 0 /etc/machine-id"})
-
 		if err != nil {
-			return err
+			// In case the command failed because of an unprivileged user,
+			// retry with sudo before giving up.
+			err = v.VMExecShell(
+				ctx, []string{vmName},
+				&ProvisionShellStep{Script: "sudo truncate -c -s 0 /etc/machine-id"})
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
If 'truncate' fails for /etc/machine-id during 'commit', attempt with 'sudo' before giving up.

Addresses #29. Tested locally with `virter vm commit` as well as `virter image build`. 

Also, fixed a typo in some help messages (`s/durign/during/`).
