### PR TITLE
check for nil desc.Metadata before attempting to unmarshal, avoiding a segfault for non-virter VMs (resolves #33)

### DIFF
--- a/internal/virter/vm.go
+++ b/internal/virter/vm.go
@@ -107,6 +107,10 @@ func (v *Virter) VMInfo(vmName string) (*VMInfo, error) {
 	}
 
 	meta := metaWrapper{}
+	if desc.Metadata == nil {
+		// not a virter VM
+		return &VMInfo{Name: vmName}, nil
+	}
 	err = xml.Unmarshal([]byte(desc.Metadata.XML), &meta)
 	if err != nil {
 		// not a virter VM


### PR DESCRIPTION
Check for nil `desc.Metadata` before attempting to unmarshall, avoiding a segfault for non-virter VMs (resolves #33)
